### PR TITLE
should change hexo-fs to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/poacher2k/hexo-featured-image.git"
   },
   "dependencies": {
-    "hexo-fs": "^0.1.5",
+    "hexo-fs": "^0.2.2",
     "yaml-front-matter": "^3.4.0"
   },
   "devDependencies": {}


### PR DESCRIPTION
Hi, I'm using node 8.9.0
but the plugin shows the warning 
`(node:8259) [DEP0061] DeprecationWarning: fs.SyncWriteStream is deprecated.`
I change hexo-fs to 0.2.2 to fix this problem.
Thanks!